### PR TITLE
feat(delete): Delete an image with backspace

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ pub enum Action {
     Move(PathBuf, PathBuf),
     Rename(String),
     MkDir(PathBuf),
+    Delete(PathBuf),
 }
 
 impl Action {
@@ -32,8 +33,8 @@ impl Action {
 
     pub fn queue_step(&self) -> usize {
         match self {
-            Action::Skip(_) | Action::Move(_, _) => 1,
-            _ => 0,
+            Action::Skip(_) | Action::Move(_, _) | Action::Delete(_) => 1,
+            Action::Rename(_) | Action::MkDir(_) => 0,
         }
     }
 }
@@ -169,6 +170,7 @@ impl App {
                     image_path.display(),
                     folder.display()
                 )),
+                Action::Delete(image) => lines.push(format!("rm \"{}\"", image.display())),
                 _ => {}
             }
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,6 +4,11 @@ use crate::app::{Action, App};
 
 pub fn handle_key_main(key: Key, app: &mut App) {
     match key {
+        Key::Backspace => {
+            app.current_image().map(|i|
+                app.push_action(Action::Delete(i))
+            );
+        },
         Key::Ctrl(key) => handle_app_key(key, app),
         Key::Char(key) => handle_mapping_key(key, app),
         _ => {}

--- a/src/render.rs
+++ b/src/render.rs
@@ -77,7 +77,7 @@ where
             [
                 Constraint::Length(3),
                 Constraint::Min(5),
-                Constraint::Length(10),
+                Constraint::Length(11),
             ]
             .as_ref(),
         )
@@ -164,6 +164,7 @@ where
         Row::new(["", ""]),
         Row::new(["Ctrl-R", "Rename image"]),
         Row::new(["Ctrl-S", "Skip image"]),
+        Row::new(["Backspace", "Delete image"]),
         Row::new(["Ctrl-Z", "Undo action"]),
         Row::new(["Ctrl-W", "Save script"]),
     ])
@@ -208,6 +209,7 @@ where
                 image.display(),
                 path.display()
             ))),
+            Action::Delete(image) => lines.push(Line::from(format!("rm \"{}\"", image.display()))),
             _ => {}
         }
     }


### PR DESCRIPTION
There are a couple of catch-all clauses when pattern matching, which hinders new enum values to get detected. We switched out one of them here, which should make for an easier time when/if adding more actions.